### PR TITLE
Do not manage firewall

### DIFF
--- a/profile-buildhost/manifests/jenkins.pp
+++ b/profile-buildhost/manifests/jenkins.pp
@@ -20,7 +20,10 @@ class buildhost::jenkins (
 ) {
   include stdlib
   include jenkins
-  class{ '::jenkins': repo => $create_jenkins_repo }
+  class{ '::jenkins': 
+    repo               => $create_jenkins_repo,
+    configure_firewall => false,
+  }
   jenkins::plugin { 'scm-api': }
   jenkins::plugin { 'git-client': }
   jenkins::plugin { 'git': }

--- a/profile-buildhost/metadata.json
+++ b/profile-buildhost/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "LunetIX/buildhost",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "author": "LunetIX",
   "summary": "compose a Mock/Jenkins build host.",
   "license": "Apache 2.0",


### PR DESCRIPTION
If you have the puppetlabs-firewall module in your environment, you need to set
the configure_firewall parameter for the jenkins module, else the jenkins
module will fail.

This is just setting an explicit default of 'false', so no firewalls are touched.
